### PR TITLE
fix collapsed styling

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -137,5 +137,9 @@
 
   @media (min-width: breakpoint.$desktop) {
     display: flex;
+
+    &.isCollapsed {
+      transform: rotate(180deg);
+    }
   }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Fixed bug when sidebar navigation is collapsed. The arrow now points left when collapsed.