### PR TITLE
render large logo on mobile only

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -50,9 +50,21 @@
 
 .logo {
   width: 7.375rem;
+  display: none;
 
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
+    display: block;
+  }
+}
+
+.logoMobile {
+  width: 7.375rem;
+  display: block;
+
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+    display: none;
   }
 }
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -27,6 +27,7 @@ export function SidebarNavigation() {
     );
     window.open(mailUrl, "_self");
   };
+
   return (
     <div
       className={classNames(
@@ -50,6 +51,12 @@ export function SidebarNavigation() {
             }
             alt="logo"
             className={styles.logo}
+          />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/icons/logo-large.svg"
+            alt="logo"
+            className={styles.logoMobile}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}


### PR DESCRIPTION
Modified `logo` class to only show on desktop, and added `logoMobile` to only show on mobile. Added `<img>` element for mobile that only loads the large logo.